### PR TITLE
optimizing shouldComponentUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,17 @@ Cursors are heavily memoized to preserve reference equality between equivalent c
 
 Due to the nature of React, this is a critical optimization when your application grows large. `react-cursor` provides this optimization as a mixin which can be used like so:
 
-`var ImmutableOptimizations = require('path/to/react-cursor').ImmutableOptimizations`
+```
+var ImmutableOptimizations = require('path/to/react-cursor').ImmutableOptimizations
 
-see [ImmutableOptimizations.js](https://github.com/dustingetz/react-cursor/blob/master/src/ImmutableOptimizations.js).
+var myClass = React.createClass({
+    mixins: [ImmutableOptimizations(refFields,ignoreFields)],
+    // ...
+});
+
+```
+
+When `shouldComponentUpdate` is run for `myClass`, props listed in `refFields` will compare old and new with a reference check, and other props will be compared with a value check (unless they are listed in `ignoreFields`). See the code at [ImmutableOptimizations.js](https://github.com/dustingetz/react-cursor/blob/master/src/ImmutableOptimizations.js).
 
 Cursors also have `pendingValue()` for use in event handlers. This solves the [double setState bug](https://github.com/facebook/react/issues/122).
 

--- a/src/ImmutableOptimizations.js
+++ b/src/ImmutableOptimizations.js
@@ -3,62 +3,22 @@ var utils = require('./util');
 'use strict';
 
 function ImmutableOptimizations (refFields, ignoredFields/*optional*/) {
-  var ignores = utils.union(refFields, ignoredFields||[]),
-      isEqual = utils.isEqual,
-      omit = utils.omit,
-      numberOfFields = refFields.length;
-  if (numberOfFields === 1){
-    var lonefield = refFields[0];
-    if (!ignores.length) {
-      // we just have a single retField which isn't ignored
-      return {
-        shouldComponentUpdate: function(nextProps){
-          return !isEqual(nextProps,this.props) || this.props[lonefield] !== nextProps[lonefield];
-        }
-      };
-    } else {
-      // we have a single retField which is ignored
-      return {
-        shouldComponentUpdate: function(nextProps){
-          return !isEqual(omit(nextProps,refFields),omit(this.props,refFields)) || this.props[lonefield] !== nextProps[lonefield];
-        }
-      };
+  var noValueCheckFields = refFields.concat(ignoredFields || []);
+  return {
+    shouldComponentUpdate: function (nextProps) {
+      var currentProps = this.props;
+
+      var valuesChanged = !utils.isEqual(
+        utils.omit(nextProps, noValueCheckFields),
+        utils.omit(currentProps, noValueCheckFields));
+
+      var refsChanged = !refFields.every(function (field) {
+        return currentProps[field] === nextProps[field];
+      });
+
+      return valuesChanged || refsChanged;
     }
-  } else {
-    if (!ignores.length){
-      // many refFields but no ignores
-      return {
-        shouldComponentUpdate: function(nextProps){
-          var currentProps = this.props, i;
-          if (!isEqual(nextProps,currentProps)){
-            return true;
-          }
-          for (i=0;i < numberOfFields; i++){
-            if (currentProps[refFields[i]]!==nextProps[refFields[i]]){
-              return true;
-            }
-          }
-          return false;
-        }
-      };
-    } else {
-      // many refFields and ignores
-      return {
-        shouldComponentUpdate: function(nextProps){
-          var currentProps = this.props, i;
-          if (!isEqual(omit(nextProps,ignores),omit(currentProps,ignores))){
-            return true;
-          }
-          for (i=0;i < numberOfFields; i++){
-            if (currentProps[refFields[i]]!==nextProps[refFields[i]]){
-              return true;
-            }
-          }
-          return false;
-        }
-      };
-    }
-  }
+  };
 }
 
 module.exports = ImmutableOptimizations;


### PR DESCRIPTION
Since `shouldComponentUpdate` is hot code, I figured it'd be worth optimising it by paying some readability. This PR therefore...
-    simplifies `refsChanged` checks if we just have a single ref field
-    simplifies `valuesChanged` if we aren't ignoring any ref fields
-    preruns the ignore union
-    minimizes object lookups
-    only calculates `refsChanged` if `valuesChanged` wasn't true
-    minimizes function calls
