### PR TITLE
fix double setState issue introduced by React 0.13

### DIFF
--- a/src/Cursor.js
+++ b/src/Cursor.js
@@ -37,8 +37,10 @@ function update(cmp, path, operation, nextValue) {
   var nextState;
 
   if (path.length > 0) {
+    var q = cmp._reactInternalInstance._pendingStateQueue;
+
     nextState = React.addons.update(
-      cmp._pendingState || cmp.state,
+      (q && util.last(q)) || cmp.state,
       path.concat(operation).reduceRight(util.unDeref, nextValue)
     );
   }


### PR DESCRIPTION
this also looked to work with `cmp._reactInternalInstance._pendingStateQueue.pop()` but I thought it best not to disturb.