### PR TITLE
update renderComponent to render in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Construct a cursor:
     var Cursor = require('path/to/react-cursor').Cursor;
 
     var cursor = Cursor.build(this) // `this` is the React component's this pointer
-                                    // or the return value of React.renderComponent
+                                    // or the return value of React.render
 
 Cursors have `refine`, `value` and expose methods for all commands in [React.addons.update](http://facebook.github.io/react/docs/update.html#available-commands). `set` is the method used most often.
 


### PR DESCRIPTION
`renderComponent` has been renamed to `render` in the current version of react: https://facebook.github.io/react/blog/2014/10/28/react-v0.12.html#new-terminology-amp-updated-apis