### PR TITLE
Fix grunt test warnings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,12 +51,12 @@ module.exports = function (grunt) {
         }
       },
 
-      mocha: {
+      mocha_phantomjs: {
         test: {
           options: {
             log: true,
             logErrors: true,
-            reporter: 'Spec',
+            reporter: 'spec',
             run: true
           },
 
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
       watch: {
         tests: {
           files: ['./test/**/*.*'],
-          tasks: ['browserify:test', 'mocha:test'],
+          tasks: ['browserify:test', 'mocha_phantomjs:test'],
           options: {
             spawn: false
           }
@@ -85,9 +85,9 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-browserify');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-karma');
-    grunt.loadNpmTasks('grunt-mocha');
+    grunt.loadNpmTasks('grunt-mocha-phantomjs');
 
-    grunt.registerTask('test', ['browserify:test', 'mocha:test', 'watch']);
+    grunt.registerTask('test', ['browserify:test', 'mocha_phantomjs:test', 'watch']);
 
     grunt.registerTask('default', ['clean', 'browserify:dev']);
     grunt.registerTask('release', ['clean', 'browserify:dev', 'browserify:build', 'browserify:dist']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,7 @@ module.exports = function (grunt) {
 
       watch: {
         tests: {
-          files: ['./test/**/*.*'],
+          files: ['./src/**/*.*', './test/**/*.*'],
           tasks: ['browserify:test', 'mocha_phantomjs:test'],
           options: {
             spawn: false

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt test"
   },
   "main": "./src/react-cursor.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-karma": "^0.9.0",
-    "grunt-mocha": "^0.4.11",
+    "grunt-mocha-phantomjs": "^0.7.0",
     "karma": "^0.12.24",
     "mocha": "^2.0.1",
     "react": "~0.12.0",

--- a/test/spec/CursorSpec.js
+++ b/test/spec/CursorSpec.js
@@ -1,3 +1,5 @@
+/* global describe, it, expect */
+
 var React = require('react');
 var Cursor = require('../../src/Cursor');
 

--- a/test/spec/UtilSpec.js
+++ b/test/spec/UtilSpec.js
@@ -1,3 +1,5 @@
+/* global describe, it, expect, beforeEach */
+
 var util = require('../../src/util');
 
 'use strict';


### PR DESCRIPTION
When run `grunt test`, it fails with following message:

```
lijunle@react-cursor:~/workspace (master) $ grunt test
Running "browserify:test" (browserify) task

Running "mocha:test" (mocha) task
Testing: ./test/html/index.html


  Util

Warning: PhantomJS timed out, possibly due to a missing Mocha run() call. Use --force to continue.

Aborted due to warnings.
lijunle@react-cursor:~/workspace (master) $ 
```

Fix it by use `grunt-mocha-phantomjs` to replace `grunt-mocha` according to [its post](http://stackoverflow.com/questions/24823544/grunt-mocha-phantomjs-timed-out).

Besides, enable `npm test` shortcut to run `grunt test`.