### PR TITLE
Avoid unnecessary renders

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@
 module.exports = function (config) {
   config.set({
     browsers: [ 'Chrome' ],
-    frameworks: [ 'mocha', 'chai' ],
+    frameworks: [ 'mocha', 'sinon-chai' ],
     reporters: [ 'mocha' ],
 
     files: [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
+    "karma-sinon-chai": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "1.6.0",
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-loader": "^5.3.2",
     "babelify": "^6.1.3",
     "chai": "^1.9.2",
+    "clone": "^1.0.2",
     "es5-shim": "^4.0.3",
     "karma": "0.12.37",
     "karma-chai": "^0.1.0",

--- a/src/Cursor.js
+++ b/src/Cursor.js
@@ -29,8 +29,20 @@ function Cursor(cmp, path, value) {
 }
 
 function update(cmp, path, operation, nextUpdate) {
-  // Backwards compatibility with non-function values of nextUpdate
-  if (typeof nextUpdate !== "function") {
+  if (typeof nextUpdate === 'function') {
+    // Don't setState if nextUpdate produces an equivalent value at the current path
+    var valAtPath = util.getRefAtPath(cmp.state, path);
+    var nextValAtPath = nextUpdate(valAtPath);
+    if (util.isEqual(nextValAtPath, valAtPath)) {
+      return;
+    }
+  } else {
+    // Don't setState if nextUpdate is equivalent to this.value
+    if (nextUpdate === this.value || util.isEqual(nextUpdate, this.value)) {
+      return;
+    }
+
+    // Backwards compatibility with non-function values of nextUpdate
     var prevValue = nextUpdate;
     nextUpdate = function ( ) { return prevValue; };
   }

--- a/src/__tests__/Cursor.spec.js
+++ b/src/__tests__/Cursor.spec.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var Cursor = require('../Cursor');
+var clone = require('clone');
 
 'use strict';
 
@@ -114,5 +115,104 @@ describe('Cursor', function () {
       return function (x) { return x / 8 }
     });
     expect(cmp.state.a).to.equal(8);
+  });
+
+  describe('Interaction with ReactComponent.setState: non-function updates', function () {
+    var cmp, setState, cursor;
+
+    var testFixtures = [
+    // initialValue,                    identicalOtherValue,            differentValue
+       [true,                           true,                           false],
+       ['foo',                          'foo',                          'bar'],
+       [42,                             42,                             25],
+       [[1, 2, 3],                      [1, 2, 3],                      [4, 5, 6]],
+       [{ foo: { bar: { baz: 'qux'}}},  { foo: { bar: { baz: 'qux'}}},  { foo: { bar: { baz: 'zig'}}}]
+    ];
+
+    testFixtures.forEach(function (fixture) {
+      var initialValue = fixture[0];
+      var identicalOtherValue = fixture[1];
+      var differentValue = fixture[2];
+
+      var initialState = {a: {b: initialValue}};
+
+      describe('When built on a component whose state is ' + JSON.stringify(initialState), function () {
+        beforeEach(function () {
+          cmp = renderComponentWithState(initialState);
+          setState = sinon.spy(cmp, 'setState');
+          cursor = Cursor.build(cmp);
+        });
+
+        afterEach(function () {
+          cmp.setState.restore();
+          cursor = null;
+          setState = null;
+          cmp = null;
+        });
+
+        it('When calling cursor.refine("a", "b").set(' + JSON.stringify(initialValue) + '), the initial value, it will not call cmp.setState', function () {
+          cursor.refine('a', 'b').set(initialValue);
+          expect(setState).to.not.have.been.called;
+        });
+
+        it('When calling cursor.refine("a", "b").set(' + JSON.stringify(identicalOtherValue) + '), an identical other value, it will not call cmp.setState', function () {
+          cursor.refine('a', 'b').set(identicalOtherValue);
+          expect(setState).to.not.have.been.called;
+        });
+
+        it('When calling cursor.refine("a", "b").set(' + JSON.stringify(differentValue) +'), a different value, it will call cmp.setState', function () {
+          cursor.refine('a', 'b').set(differentValue);
+          expect(setState).to.have.been.calledOnce;
+        });
+      });
+    });
+  });
+
+  describe('Interaction with ReactComponent.setState: function updates', function () {
+    var cmp, setState, cursor;
+
+    var testFixtures = [
+    // initialValue,                   [swapToSameValueButDifferentRef, label],                [swapToDifferentValue, label]
+       [[1, 2, 3],                     [a => a.map(i => i),             'array map identity'], [a => a.map(i => i + 3), 'array map plus 3']],
+       [{ foo: { bar: { baz: 'qux'}}}, [clone,                          'clone object'],       [o => o.swapped = true, 'object assoc :swapped true']]
+    ];
+
+
+    testFixtures.forEach(function (fixture) {
+      var initialValue = fixture[0];
+
+      var swapToSameValueButDifferentRef = fixture[1][0];
+      var firstLabel = fixture[1][1];
+
+      var swapToDifferentValue = fixture[2][0];
+      var secondLabel = fixture[2][1];
+
+      var initialState = {a: {b: initialValue}};
+
+      describe('When built on a component whose state is ' + JSON.stringify(initialState), function () {
+        beforeEach(function () {
+          cmp = renderComponentWithState(initialState);
+          setState = sinon.spy(cmp, 'setState');
+          cursor = Cursor.build(cmp);
+        });
+
+        afterEach(function () {
+          cmp.setState.restore();
+          cursor = null;
+          setState = null;
+          cmp = null;
+        });
+
+        it('When calling cursor.refine("a", "b").set(' + firstLabel + '), a function producing a value equivalent to the initialValue, it will not call cmp.setState', function () {
+          cursor.refine('a', 'b').set(swapToSameValueButDifferentRef);
+          expect(setState).to.not.have.been.called;
+        });
+
+        it('When calling cursor.refine("a", "b").set(' + secondLabel + '), a function producing a different value, it will call cmp.setState', function () {
+          cursor.refine('a', 'b').set(swapToDifferentValue);
+          expect(setState).to.have.been.calledOnce;
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This works for non-function values passed to `update`, updating with function values will need more thought.

Happy to receive feedback on what I have so far.