### PR TITLE
Implement immutable value in dev mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "array-union": "^1.0.0",
     "deep-equal": "^0.2.1",
+    "lodash": "^3.10.1",
     "omit-keys": "^0.1.0"
   }
 }

--- a/src/Cursor.js
+++ b/src/Cursor.js
@@ -26,6 +26,11 @@ function Cursor(cmp, path, value) {
     var nextValue = util.getRefAtPath(this.value, Array.prototype.slice.call(arguments, 0));
     return build(cmp, nextPath, nextValue); // memoized
   };
+
+  if (Cursor.debug && typeof Object.freeze === 'function') {
+    util.deepFreeze(this);
+    util.deepFreeze(value);
+  }
 }
 
 function update(cmp, path, operation, nextUpdate) {
@@ -74,6 +79,6 @@ var build = cursorBuildMemoizer(function (cmp, path, value) {
 
 Cursor.build = build;
 
-Cursor.debug = false;
+Cursor.debug = process.env.NODE_ENV !== 'production';
 
 module.exports = Cursor;

--- a/src/__tests__/Cursor.spec.js
+++ b/src/__tests__/Cursor.spec.js
@@ -20,9 +20,9 @@ function renderComponentWithState(initialState) {
 }
 
 describe('Cursor', function () {
-  it('Can load the library in the unit tests', function () {
-    expect(Cursor).not.equal(undefined);
-    expect(Cursor.debug).to.equal(false);
+  it('should load the library in the unit tests', function () {
+    expect(Cursor).to.be.a('function');
+    expect(Cursor.debug).to.equal(true); // NODE_ENV !== production
   });
 
   it("can we make an instance of a react cmp and get at the state", function () {

--- a/src/__tests__/Cursor.spec.js
+++ b/src/__tests__/Cursor.spec.js
@@ -115,4 +115,42 @@ describe('Cursor', function () {
     });
     expect(cmp.state.a).to.equal(8);
   });
+
+  it('should eventually throw an exception when detecting mutations to a root cursor.value', function () {
+    var cmp = renderComponentWithState({ a: 42 });
+    var c = Cursor.build(cmp);
+
+    expect(() => c.value = { b: 43 }).to.throw(Error);
+  });
+
+  it('should eventually throw an exception when detecting mutations to a refined cursor.value', function () {
+    var cmp = renderComponentWithState({ a: 42 });
+    var c = Cursor.build(cmp);
+    var r = c.refine('a');
+
+    expect(() => r.value = 43).to.throw(Error);
+  });
+
+  it('should eventually throw an exception when detecting mutations to a refined grandchild cursor value', function () {
+    var cmp = renderComponentWithState({ a: { b: 42 } });
+    var root = Cursor.build(cmp);
+    var child = root.refine('a');
+    var grandChild = child.refine('b');
+
+    expect(() => grandChild.value = 43).to.throw(Error);
+  });
+
+  it('should eventually throw an exception when adding new keys to a cursor value', function () {
+    var cmp = renderComponentWithState({ a: 42 });
+    var root = Cursor.build(cmp);
+
+    expect(() => root.value.b = 43).to.throw(Error);
+  });
+
+  it('should eventually throw an exception when removing keys from a cursor value', function () {
+    var cmp = renderComponentWithState({ a: 42, b: 43 });
+    var root = Cursor.build(cmp);
+
+    expect(() => delete root.value.b).to.throw(Error);
+  });
 });

--- a/src/__tests__/Util.spec.js
+++ b/src/__tests__/Util.spec.js
@@ -5,13 +5,16 @@ var util = require('../util');
 'use strict';
 
 describe('Util', function() {
-  var items;
 
-  beforeEach(function() {
-    items = ['a', 'b', 'c'];
-  });
+  describe('Util.last', function () {
+    var items;
 
-  it('#last should find last item in array', function () {
-    expect(util.last(items)).to.equal('c');
+    beforeEach(function() {
+      items = ['a', 'b', 'c'];
+    });
+
+    it('should find last item in array', function () {
+      expect(util.last(items)).to.equal('c');
+    });
   });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -120,7 +120,27 @@ function memoizeFactory (resolver) {
   return memoize;
 }
 
+// copy from MDN example: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#Examples
+function deepFreeze(obj) {
+  // Retrieve the property names defined on obj
+  var propNames = Object.getOwnPropertyNames(obj);
+
+  // Freeze properties before freezing self
+  propNames.forEach(function(name) {
+    var prop = obj[name];
+
+    // Freeze prop if it is an object
+    if (typeof prop == 'object' && !Object.isFrozen(prop)) {
+      deepFreeze(prop);
+    }
+  });
+
+  // Freeze self
+  return Object.freeze(obj);
+}
+
 module.exports = {
+  deepFreeze,
   getRefAtPath: getRefAtPath,
   deref: deref,
   unDeref: unDeref,

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var isEqual = require('deep-equal');
 var union = require('array-union');
 var omit = require('omit-keys');
@@ -122,6 +123,10 @@ function memoizeFactory (resolver) {
 
 // copy from MDN example: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#Examples
 function deepFreeze(obj) {
+  if (!_.isObject(obj)) {
+    return obj;
+  }
+
   // Retrieve the property names defined on obj
   var propNames = Object.getOwnPropertyNames(obj);
 


### PR DESCRIPTION
- Resolve #54 
- Detect dev mode according to `NODE_ENV` environment variable.
- Deep freeze value object with [the example from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#Examples).
- Re-user some of @danielmiladinov 's code

**Note**:

Please be attention with the behavior of `Object.freeze`. According to MDN's [description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#Description):

- If no `use strict`, nothing happens when touch the value property
- If `use strict`, `TypeError` is thrown.