### PR TITLE
Add test to prove the behavior of refine & set on non-existent keys, also add Cursor.assoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "lodash.omit": "^4.0.0",
     "lodash.reduce": "^4.0.0",
     "react-addons-update": "^0.14.2",
-    "update-in": "0.0.1-alpha.4"
+    "update-in": "0.0.1-alpha.5"
   }
 }

--- a/src/Cursor.js
+++ b/src/Cursor.js
@@ -1,5 +1,5 @@
-import {merge, push, unshift, splice} from 'update-in';
 import memoized from './util/memoized';
+import CursorOperations from './CursorOperations';
 import {getIn, rootAt} from './util/associative';
 import hashRecord from './util/hashRecord';
 import refToHash from './util/refToHash';
@@ -15,17 +15,12 @@ let makeRefinedSwap = memoized(
   (swapFn, paths) => (f) => swapFn(rootAt(paths, f)));
 
 
-class Cursor {
+class Cursor extends CursorOperations {
   constructor (value, swapFn) {
+    super();
     this.value = () => value;
     this.refine = (...morePaths) => NewCursor(getIn(value, morePaths), makeRefinedSwap(swapFn, morePaths));
     this.swap = (f, ...args) => swapFn((v) => f.apply(null, [v].concat(args)));
-
-    this.set = (val) => this.swap(v => val);
-    this.merge = (val) => this.swap(merge, val);
-    this.push = (xs) => this.swap(push, xs);
-    this.unshift = (xs) => this.swap(unshift, xs);
-    this.splice = (xs) => this.swap(splice, xs);
 
     debug && deepFreeze(value);
   }

--- a/src/CursorOperations.js
+++ b/src/CursorOperations.js
@@ -1,0 +1,9 @@
+import {merge, push, unshift, splice} from 'update-in';
+
+export default class CursorOperations {
+  set (val) { return this.swap(_ => val); }
+  merge (val) { return this.swap(merge, val); }
+  push (xs) { return this.swap(push, xs); }
+  unshift (xs) { return this.swap(unshift, xs); }
+  splice (xs) { return this.swap(splice, xs); }
+};

--- a/src/CursorOperations.js
+++ b/src/CursorOperations.js
@@ -1,4 +1,4 @@
-import {merge, push, unshift, splice} from 'update-in';
+import {merge, push, unshift, splice, dissoc} from 'update-in';
 
 export default class CursorOperations {
   set (val) { return this.swap(_ => val); }
@@ -6,4 +6,5 @@ export default class CursorOperations {
   push (xs) { return this.swap(push, xs); }
   unshift (xs) { return this.swap(unshift, xs); }
   splice (xs) { return this.swap(splice, xs); }
+  dissoc (...keys) { return this.swap.apply(this, [dissoc].concat(keys)); }
 };

--- a/src/CursorOperations.js
+++ b/src/CursorOperations.js
@@ -1,4 +1,4 @@
-import {merge, push, unshift, splice, dissoc} from 'update-in';
+import {merge, push, unshift, splice, assoc, dissoc} from 'update-in';
 
 export default class CursorOperations {
   set (val) { return this.swap(_ => val); }
@@ -6,5 +6,6 @@ export default class CursorOperations {
   push (xs) { return this.swap(push, xs); }
   unshift (xs) { return this.swap(unshift, xs); }
   splice (xs) { return this.swap(splice, xs); }
+  assoc (...kvs) { return this.swap.apply(this, [assoc].concat(kvs)); }
   dissoc (...keys) { return this.swap.apply(this, [dissoc].concat(keys)); }
 };

--- a/src/RefCursor.js
+++ b/src/RefCursor.js
@@ -1,4 +1,5 @@
 import {merge, push, unshift, splice} from 'update-in';
+import CursorOperations from './CursorOperations';
 import memoized from './util/memoized';
 import {getIn, rootAt} from './util/associative';
 import hashRecord from './util/hashRecord';
@@ -16,17 +17,12 @@ let makeRefinedDeref = memoized(
   (deref, paths) => () => getIn(deref(), paths));
 
 
-class RefCursor {
+class RefCursor extends CursorOperations {
   constructor (deref, swapFn) {
+    super();
     this.value = deref;
     this.refine = (...morePaths) => NewRefCursor(makeRefinedDeref(deref, morePaths), makeRefinedSwap(swapFn, morePaths));
     this.swap = (f, ...args) => swapFn((v) => f.apply(null, [v].concat(args)));
-
-    this.set = (val) => this.swap(v => val);
-    this.merge = (val) => this.swap(merge, val);
-    this.push = (xs) => this.swap(push, xs);
-    this.unshift = (xs) => this.swap(unshift, xs);
-    this.splice = (xs) => this.swap(splice, xs);
 
     // RefCursors don't own a value, so they aren't responsible for freezing it.
   }

--- a/src/__tests__/CursorOperations.spec.js
+++ b/src/__tests__/CursorOperations.spec.js
@@ -23,6 +23,14 @@ describe('Cursor updates', () => {
       expect(storeValue().a).to.deep.equal({b: 43});
     },
 
+    'refine and set creates key if non-existent': () => {
+      expect(storeValue()).to.deep.equal(initialState);
+      expect(storeValue().e).to.equal(undefined);
+      let e = {a: {b: 43}, c: [2, 3, 4], d: 44};
+      cur.refine('e').set(e);
+      expect(storeValue().e).to.deep.equal(e);
+    },
+
     'push': () => {
       var c = cur.refine('c');
       c.push([4]);

--- a/src/__tests__/CursorOperations.spec.js
+++ b/src/__tests__/CursorOperations.spec.js
@@ -6,7 +6,7 @@ import {Store, renderComponentWithState} from './CursorTestUtil';
 
 describe('Cursor updates', () => {
   let cur, storeValue;
-  const initialState = {a: {b: 42}, c: [1, 2, 3]};
+  const initialState = {a: {b: 42}, c: [1, 2, 3], d: {foo: 1, bar: 2, baz: {qux: 3}}};
 
 
   let suite = {
@@ -45,6 +45,40 @@ describe('Cursor updates', () => {
       expect(storeValue().c).to.deep.equal([1, 4, 3]);
       c.splice([[0, 1, 6, 5], [4, 0, 2, 1]]);
       expect(storeValue().c).to.deep.equal([6, 5, 4, 3, 2, 1]);
+    },
+
+    'dissoc array': () => {
+      let c = cur.refine('c');
+      expect(storeValue().c).to.deep.equal([1, 2, 3]);
+
+      c.dissoc(0);
+      expect(storeValue().c).to.deep.equal([2, 3]);
+
+      c.push([4, 5, 6]);
+
+      c.dissoc(2);
+      expect(storeValue().c).to.deep.equal([2, 3, 5, 6]);
+
+      c.push([7, 8, 9]);
+      c.dissoc(2, 3, 4);
+
+      expect(storeValue().c).to.deep.equal([2, 3, 8, 9]);
+
+      c.push([10, 11, 12]);
+      c.dissoc(1, 3, 5);
+
+      expect(storeValue().c).to.deep.equal([2, 8, 10, 12]);
+    },
+
+    'dissoc object': () => {
+      let d = cur.refine('d');
+      expect(storeValue().d).to.deep.equal({foo: 1, bar: 2, baz: {qux: 3}});
+
+      d.dissoc('baz');
+      expect(storeValue().d).to.deep.equal({foo: 1, bar: 2});
+
+      d.dissoc('foo', 'bar');
+      expect(storeValue().d).to.deep.equal({});
     },
 
     'merge': () => {

--- a/src/__tests__/CursorOperations.spec.js
+++ b/src/__tests__/CursorOperations.spec.js
@@ -31,6 +31,53 @@ describe('Cursor updates', () => {
       expect(storeValue().e).to.deep.equal(e);
     },
 
+    'assoc can append a single new value to the end of an array': () => {
+      expect(storeValue()).to.deep.equal(initialState);
+
+      let c = cur.refine('c');
+      c.assoc(3, 4);
+
+      expect(storeValue().c).to.deep.equal([1, 2, 3, 4]);
+
+      expect(() => c.assoc(5, '5 is greater than array length')).to.throw(RangeError);
+    },
+
+    'assoc replaces array values': () => {
+      expect(storeValue()).to.deep.equal(initialState);
+
+      let c = cur.refine('c');
+      c.assoc(0, 'a');
+
+      expect(storeValue().c).to.deep.equal(['a', 2, 3]);
+
+      c.assoc(1, 'b', 2, 'c');
+      expect(storeValue().c).to.deep.equal(['a', 'b', 'c']);
+    },
+
+    'assoc creates new object key values': () => {
+      expect(storeValue()).to.deep.equal(initialState);
+
+      let a = cur.refine('a');
+      a.assoc('a', 21);
+      expect(storeValue().a).to.deep.equal({a: 21, b: 42});
+
+      a.assoc('c', 63, 'd', 84);
+      expect(storeValue().a).to.deep.equal({a: 21, b: 42, c: 63, d: 84});
+    },
+
+    'assoc replaces object key values': () => {
+      expect(storeValue()).to.deep.equal(initialState);
+
+      let d = cur.refine('d');
+      d.assoc('foo', 'swapped');
+
+      expect(storeValue().d).to.deep.equal({foo: 'swapped', bar: 2, baz: {qux: 3}});
+
+      d.assoc('bar', 'also', 'baz', 'changed');
+
+      expect(storeValue().d).to.deep.equal({foo: 'swapped', bar: 'also', baz: 'changed'});
+    },
+
     'push': () => {
       var c = cur.refine('c');
       c.push([4]);

--- a/src/util/associative.js
+++ b/src/util/associative.js
@@ -1,11 +1,14 @@
 import {updateIn} from 'update-in';
 import reduce from 'lodash.reduce';
 
+let debug = process.env.NODE_ENV !== 'production';
 
 export let rootAt = (segments, fn) => (value) => updateIn(value, segments, fn);
 
 let get = (obj, key) => {
-  console.assert(key in obj, `Bad cursor refine: '${key}' not found in `, obj);
+  if (debug && !(key in obj)) {
+    console.warn(`Refining cursor to non-existent key: '${key}' not found in `, obj);
+  }
   return obj[key];
 };
 


### PR DESCRIPTION
Also relax the assert in function get of associative.js to a
console.warn, since refining to a non-existent key may be the behavior
desired by clients.

Fixes #92